### PR TITLE
Fix/status create page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "poker-planning",
-	"version": "1.2.1",
+	"version": "1.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "poker-planning",
-			"version": "1.2.1",
+			"version": "1.3.1",
 			"dependencies": {
 				"@fortawesome/fontawesome-free": "^6.6.0",
-				"@vercel/analytics": "^1.4.1",
+				"@vercel/analytics": "^1.5.0",
 				"chroma-js": "^3.1.2",
 				"preprocess": "^3.2.0",
 				"socket.io-client": "^4.8.1",
@@ -1643,9 +1643,9 @@
 			}
 		},
 		"node_modules/@vercel/analytics": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.4.1.tgz",
-			"integrity": "sha512-ekpL4ReX2TH3LnrRZTUKjHHNpNy9S1I7QmS+g/RQXoSUQ8ienzosuX7T9djZ/s8zPhBx1mpHP/Rw5875N+zQIQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+			"integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
 			"license": "MPL-2.0",
 			"peerDependencies": {
 				"@remix-run/react": "^2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "poker-planning",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"type": "module",
 	"scripts": {
 		"startserv": "node server.js",
@@ -32,7 +32,7 @@
 	},
 	"dependencies": {
 		"@fortawesome/fontawesome-free": "^6.6.0",
-		"@vercel/analytics": "^1.4.1",
+		"@vercel/analytics": "^1.5.0",
 		"chroma-js": "^3.1.2",
 		"preprocess": "^3.2.0",
 		"socket.io-client": "^4.8.1",

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -116,7 +116,7 @@
 		type = window.localStorage.getItem('type') || 'TSHIRT';
 		team = window.localStorage.getItem('team') || '';
 
-		status == 'create';
+		status = 'create';
 	});
 
 	const addNewDeck = () => {

--- a/src/routes/sitemap.xml/+server.js
+++ b/src/routes/sitemap.xml/+server.js
@@ -17,7 +17,7 @@ export async function GET() {
 
             <url>
                 <loc>https://anotherpp.vercel.app/create</loc>
-                <lastmod>2025-01-05T16:15:00+00:00</lastmod>
+                <lastmod>2025-02-20T11:15:00+00:00</lastmod>
             </url>
 
             <url>
@@ -27,17 +27,17 @@ export async function GET() {
 
             <url>
                 <loc>https://anotherpp.vercel.app/manager</loc>
-                <lastmod>2025-01-05T16:15:00+00:00</lastmod>
+                <lastmod>2025-02-20T11:15:00+00:00</lastmod>
             </url>
 
             <url>
                 <loc>https://anotherpp.vercel.app/rooms</loc>
-                <lastmod>2025-01-05T16:15:00+00:00</lastmod>
+                <lastmod>2025-02-20T11:15:00+00:00</lastmod>
             </url>
 
             <url>
                 <loc>https://anotherpp.vercel.app/feedback</loc>
-                <lastmod>2025-01-22T23:15:00+00:00</lastmod>
+                <lastmod>2025-02-20T11:15:00+00:00</lastmod>
             </url>
 
             <url>


### PR DESCRIPTION
This pull request includes several updates and fixes across different files. The most important changes include a version bump in `package.json`, dependency updates, a bug fix in `+page.svelte`, and updates to the sitemap timestamps.

Version and dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Bumped the version from `1.3.0` to `1.3.1`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L35-R35): Updated `@vercel/analytics` dependency from `^1.4.1` to `^1.5.0`.

Bug fix:

* [`src/routes/create/+page.svelte`](diffhunk://#diff-5d981345e53db4e71774b12c64ec4c1158b0dc79fbfd315e40aa9cfcfde7442cL119-R119): Fixed a typo in the assignment of `status` from `==` to `=`.

Sitemap updates:

* [`src/routes/sitemap.xml/+server.js`](diffhunk://#diff-d8e5876c4cb7d9384651d838b62b75a9adc97544a808513bb2b946552475d975L20-R20): Updated the `lastmod` timestamps for multiple URLs to reflect the new modification date of `2025-02-20T11:15:00+00:00`. [[1]](diffhunk://#diff-d8e5876c4cb7d9384651d838b62b75a9adc97544a808513bb2b946552475d975L20-R20) [[2]](diffhunk://#diff-d8e5876c4cb7d9384651d838b62b75a9adc97544a808513bb2b946552475d975L30-R40)