### PR TITLE
fix: layering issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "poker-planning",
-	"version": "1.7.2",
+	"version": "1.7.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "poker-planning",
-	"version": "1.7.2",
+	"version": "1.7.3",
 	"type": "module",
 	"scripts": {
 		"startserv": "node server.js",

--- a/src/lib/components/Code.svelte
+++ b/src/lib/components/Code.svelte
@@ -75,7 +75,7 @@
 		backdrop-filter: blur(7px) brightness(80%);
 		top: 0;
 		left: 0;
-		z-index: 10;
+		z-index: 100;
 		cursor: pointer;
 
 		h3 {

--- a/src/routes/manager/[id]/+page.svelte
+++ b/src/routes/manager/[id]/+page.svelte
@@ -643,7 +643,7 @@
 				position: sticky;
 				top: 0;
 				padding-top: 1em;
-				z-index: 99;
+				z-index: 50;
 				background-color: var(--primary-50);
 
 				.button-user-type-container {


### PR DESCRIPTION
This pull request includes a version bump for the package and adjustments to `z-index` values in the styles of two components to address layering issues.

### Version update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `1.7.2` to `1.7.3`.

### Style adjustments:
* [`src/lib/components/Code.svelte`](diffhunk://#diff-389cd2492b7f11a9a749015fbf3614df1df14a34fe82b95bf24ba803be55f62fL78-R78): Increased the `z-index` value from `10` to `100` to ensure the backdrop appears above other elements.
* `src/routes/manager/[id]/+page.svelte`: Decreased the `z-index` value from `99` to `50` for the sticky element to resolve overlapping issues with other components. ([src/routes/manager/[id]/+page.svelteL646-R646](diffhunk://#diff-876a2a3f3a4564ea7e96a79be11bfda6b72fcf83d77c908008d39b37e41c42efL646-R646))