### PR TITLE
Feat: add imgur fallback image upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "poker-planning",
-	"version": "1.10.1",
+	"version": "1.10.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "poker-planning",
-			"version": "1.10.1",
+			"version": "1.10.2",
 			"dependencies": {
 				"@fortawesome/fontawesome-free": "^6.6.0",
 				"@vercel/analytics": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "poker-planning",
-	"version": "1.10.1",
+	"version": "1.10.2",
 	"type": "module",
 	"scripts": {
 		"startserv": "node backend/server.js",


### PR DESCRIPTION
This pull request updates the image upload API endpoint to improve error handling and add a fallback mechanism. Now, if the primary image upload fails, the server will attempt to upload the image to Imgur instead and return the Imgur link.

**Error handling and fallback improvements:**

* Added a fallback to upload images to Imgur using the `uploadToImgur` function if the primary upload fails, returning the Imgur URL in the response (`src/routes/_api/upload/+server.js`).

**Code cleanup and consistency:**

* Renamed the `blob` variable to `base64` for clarity and updated all references accordingly (`src/routes/_api/upload/+server.js`). [[1]](diffhunk://#diff-bc2522a75c2988e0ac38f0b0387cbf214660174727fb036318a98fbd824aba0bR2-R9) [[2]](diffhunk://#diff-bc2522a75c2988e0ac38f0b0387cbf214660174727fb036318a98fbd824aba0bL29-R30)